### PR TITLE
Dev/v1.0.7 Adding update support for dynamically changed labels / guis

### DIFF
--- a/Source/Pd/PdGui.cpp
+++ b/Source/Pd/PdGui.cpp
@@ -206,6 +206,69 @@ namespace pd
         return 1.f;
     }
     
+     float Gui::hasChanged() const noexcept
+{
+        if(!m_ptr)
+            return 0.f;
+        if(m_type == Type::HorizontalSlider)
+        {
+	    int status;
+	    status = static_cast<t_hslider*>(m_ptr)->x_gui.x_dirty;
+	    static_cast<t_hslider*>(m_ptr)->x_gui.x_dirty=0;
+	    return (status);
+        }
+        else if(m_type == Type::VerticalSlider)
+        {
+	    int status;
+	    status = static_cast<t_vslider*>(m_ptr)->x_gui.x_dirty;
+	    static_cast<t_vslider*>(m_ptr)->x_gui.x_dirty=0;
+	    return (status);
+        }
+        else if(m_type == Type::Toggle)
+        {
+	    int status;
+	    status = static_cast<t_toggle*>(m_ptr)->x_gui.x_dirty;
+	    static_cast<t_toggle*>(m_ptr)->x_gui.x_dirty=0;
+	    return (status);
+        }
+        else if(m_type == Type::Number)
+        {
+	    int status;
+	    status = static_cast<t_my_numbox*>(m_ptr)->x_gui.x_dirty;
+	    static_cast<t_my_numbox*>(m_ptr)->x_gui.x_dirty=0;
+	    return (status);
+        }
+        else if(m_type == Type::HorizontalRadio)
+        {
+	    int status;
+	    status = static_cast<t_hdial*>(m_ptr)->x_gui.x_dirty;
+	    static_cast<t_hdial*>(m_ptr)->x_gui.x_dirty=0;
+	    return (status);
+        }
+        else if(m_type == Type::VerticalRadio)
+        {
+	    int status;
+	    status = static_cast<t_vdial*>(m_ptr)->x_gui.x_dirty;
+	    static_cast<t_vdial*>(m_ptr)->x_gui.x_dirty=0;
+	    return (status);
+        }
+        else if(m_type == Type::Bang)
+        {
+	    int status;
+	    status = static_cast<t_bng*>(m_ptr)->x_gui.x_dirty;
+	    static_cast<t_bng*>(m_ptr)->x_gui.x_dirty=0;
+	    return (status);
+        }
+	else if(m_type == Type::Panel)
+        {
+	    int status;
+	    status = static_cast<t_my_canvas*>(m_ptr)->x_gui.x_dirty;
+	    static_cast<t_my_canvas*>(m_ptr)->x_gui.x_dirty=0;
+	    return (status);
+        }
+        return 0.f;
+    }
+
     float Gui::getValue() const noexcept
     {
         if(!m_ptr)
@@ -244,7 +307,7 @@ namespace pd
         }
         else if(m_type == Type::AtomNumber)
         {
-            return atom_getfloat(&(static_cast<t_fake_gatom*>(m_ptr)->a_atom));
+	    return atom_getfloat(&(static_cast<t_fake_gatom*>(m_ptr)->a_atom));
         }
         return 0.f;
     }

--- a/Source/Pd/PdGui.hpp
+++ b/Source/Pd/PdGui.hpp
@@ -84,6 +84,8 @@ namespace pd
         float getMaximum() const noexcept;
         
         float getValue() const noexcept;
+
+	float hasChanged() const noexcept;
         
         void setValue(float value) noexcept;
         

--- a/Source/Pd/PdInstance.cpp
+++ b/Source/Pd/PdInstance.cpp
@@ -23,7 +23,7 @@ extern "C"
     {
         static void instance_multi_bang(pd::Instance* ptr, const char *recv)
         {
-            ptr->m_message_queue.try_enqueue({std::string("bang")});
+           ptr->m_message_queue.try_enqueue({std::string("bang")});
         }
         
         static void instance_multi_float(pd::Instance* ptr, const char *recv, float f)

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -61,7 +61,7 @@ void CamomileEditor::updateObjects()
     for(auto& gui : m_processor.getPatch().getGuis())
     {
         PluginEditorObject* obj = PluginEditorObject::createTyped(*this, gui);
-        if(obj)
+ 	       if(obj)
         {
             obj->setTopLeftPosition(obj->getX() - pbounds[0], obj->getY() - pbounds[1]);
             if(bounds.contains(obj->getBounds()))
@@ -89,7 +89,7 @@ void CamomileEditor::timerCallback()
 
 void CamomileEditor::paint (Graphics& g)
 {
-    g.fillAll(Colours::white);
+    g.fillAll(Colours::grey);
     if(!CamomileEnvironment::isValid())
     {
         g.setColour(Colours::black);

--- a/Source/PluginEditorInteraction.cpp
+++ b/Source/PluginEditorInteraction.cpp
@@ -129,6 +129,7 @@ bool CamomileEditorKeyManager::keyModifiersChanged(const ModifierKeys& modifiers
 
 const std::string CamomileEditorMouseManager::string_gui = std::string("gui");
 const std::string CamomileEditorMouseManager::string_mouse = std::string("mouse");
+const std::string CamomileEditorMouseManager::string_mouse_drag = std::string("mouse_drag");
 
 void CamomileEditorMouseManager::startEdition()
 {
@@ -138,6 +139,12 @@ void CamomileEditorMouseManager::startEdition()
 void CamomileEditorMouseManager::stopEdition()
 {
     m_processor.enqueueMessages(string_gui, string_mouse, {0.f});
+}
+
+
+ void CamomileEditorMouseManager::sendMouse(float x, float y)
+{
+    m_processor.enqueueMessages(string_gui, string_mouse_drag, {x,y});
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////

--- a/Source/PluginEditorInteraction.h
+++ b/Source/PluginEditorInteraction.h
@@ -58,6 +58,7 @@ public:
     CamomileEditorMouseManager(CamomileAudioProcessor& processor) : m_processor(processor) {}
     void startEdition();
     void stopEdition();
+    void sendMouse(float , float );
     
     CamomileAudioProcessor& getProcessor() { return m_processor; }
 private:
@@ -65,6 +66,7 @@ private:
     
     static const std::string string_gui;
     static const std::string string_mouse;
+    static const std::string string_mouse_drag;
     
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(CamomileEditorMouseManager)
 };

--- a/Source/PluginEditorObject.cpp
+++ b/Source/PluginEditorObject.cpp
@@ -115,12 +115,25 @@ void PluginEditorObject::update()
     if(edited == false)
     {
         float const v = gui.getValue();
-        if(v != value)
+        if((v != value)||(gui.hasChanged()))
         {
             value = v;
             repaint();
+	    if(objectLabel)
+	    {
+                pd::Label const lbl = gui.getLabel();
+                const String text = String(lbl.getText());
+                const Font ft = CamoLookAndFeel::getFont(lbl.getFontName()).withPointHeight(static_cast<float>(lbl.getFontHeight()));
+                const int width = ft.getStringWidth(text) + 1;
+                const int height = ft.getHeight();
+                const std::array<int, 2> position = lbl.getPosition();
+                objectLabel->setBounds(position[0], position[1] - height / 2, width, height);
+                objectLabel->setText(text, NotificationType::dontSendNotification);
+                objectLabel->setColour(Label::textColourId, Colour(static_cast<uint32>(lbl.getColor())));
+		objectLabel->repaint();
+	    }
         }
-    }
+    }    
 }
 
 Label* PluginEditorObject::getLabel()
@@ -143,8 +156,10 @@ Label* PluginEditorObject::getLabel()
         label->setEditable(false, false);
         label->setInterceptsMouseClicks(false, false);
         label->setColour(Label::textColourId, Colour(static_cast<uint32>(lbl.getColor())));
+	objectLabel=label;
         return label;
     }
+    objectLabel = nullptr;
     return nullptr;
 }
 
@@ -155,6 +170,9 @@ Label* PluginEditorObject::getLabel()
 
 void GuiBang::paint(Graphics& g)
 {
+    std::array<int, 4> const bounds(gui.getBounds());
+    setBounds(bounds[0], bounds[1], bounds[2], bounds[3]);
+
     const float border = 1.f;
     const float w = static_cast<float>(getWidth() - border * 2);
     g.fillAll(Colour(static_cast<uint32>(gui.getBackgroundColor())));
@@ -176,6 +194,7 @@ void GuiBang::mouseDown(const MouseEvent& e)
     stopEdition();
 }
 
+
 void GuiBang::mouseUp(const MouseEvent& e)
 {
     if(getValueOriginal() > std::numeric_limits<float>::epsilon())
@@ -184,12 +203,15 @@ void GuiBang::mouseUp(const MouseEvent& e)
     }
 }
 
+
 //////////////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////     TOGGLE        ///////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////////////////
 
 void GuiToggle::paint(Graphics& g)
 {
+    std::array<int, 4> const bounds(gui.getBounds());
+    setBounds(bounds[0], bounds[1], bounds[2], bounds[3]);
     const float border = 1.f;
     g.fillAll(Colour(static_cast<uint32>(gui.getBackgroundColor())));
     if(getValueOriginal() > std::numeric_limits<float>::epsilon())
@@ -217,6 +239,8 @@ void GuiToggle::mouseDown(const MouseEvent& e)
 
 void GuiSliderHorizontal::paint(Graphics& g)
 {
+    std::array<int, 4> const bounds(gui.getBounds());
+    setBounds(bounds[0], bounds[1], bounds[2], bounds[3]);
     const float border = 1.f;
     const float crsor  = 3.f;
     const float w = static_cast<float>(getWidth()) - border * 2.f;
@@ -290,6 +314,8 @@ void GuiSliderHorizontal::mouseUp(const MouseEvent& e)
     
 void GuiSliderVertical::paint(Graphics& g)
 {
+    std::array<int, 4> const bounds(gui.getBounds());
+    setBounds(bounds[0], bounds[1], bounds[2], bounds[3]);
     const float border = 1.f;
     const float crsor = 3.f;
     const float w = static_cast<float>(getWidth() - border * 2);
@@ -349,6 +375,7 @@ void GuiSliderVertical::mouseDrag(const MouseEvent& e)
             setValueScaled(m_temp + val);
         }
     }
+    patch.sendMouse(e.x,e.y);
     repaint();
 }
 
@@ -363,6 +390,8 @@ void GuiSliderVertical::mouseUp(const MouseEvent& e)
 
 void GuiRadioHorizontal::paint(Graphics& g)
 {
+    std::array<int, 4> const bounds(gui.getBounds());
+    setBounds(bounds[0], bounds[1], bounds[2], bounds[3]);
     const float border = 1.f;
     const float extra  = 2.f;
     const float h  = static_cast<float>(getHeight());
@@ -394,6 +423,8 @@ void GuiRadioHorizontal::mouseDown(const MouseEvent& e)
 
 void GuiRadioVertical::paint(Graphics& g)
 {
+    std::array<int, 4> const bounds(gui.getBounds());
+    setBounds(bounds[0], bounds[1], bounds[2], bounds[3]);
     const float border = 1.f;
     const float extra  = 2.f;
     const float h  = static_cast<float>(getHeight()) / static_cast<float>(max + 1);
@@ -426,12 +457,15 @@ void GuiRadioVertical::mouseDown(const MouseEvent& e)
 GuiPanel::GuiPanel(CamomileEditorMouseManager& p, pd::Gui& g) : PluginEditorObject(p, g)
 {
     setInterceptsMouseClicks(false, false);
-    edited = true;
+    //edited = true;
 }
 
 void GuiPanel::paint(Graphics& g)
 {
-    g.fillAll(Colour(static_cast<uint32>(gui.getBackgroundColor())));
+ 	std::array<int, 4> const bounds(gui.getBounds());
+    	setBounds(bounds[0], bounds[1], bounds[2], bounds[3]);
+
+	g.fillAll(Colour(static_cast<uint32>(gui.getBackgroundColor())));
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -527,6 +561,8 @@ GuiNumber::GuiNumber(CamomileEditorMouseManager& p, pd::Gui& g) : GuiTextEditor(
 
 void GuiNumber::paint(Graphics& g)
 {
+    std::array<int, 4> const bounds(gui.getBounds());
+    setBounds(bounds[0], bounds[1], bounds[2], bounds[3]);
     const float border = 1.f;
     const float h = static_cast<float>(getHeight());
     const float w = static_cast<float>(getWidth());

--- a/Source/PluginEditorObject.hpp
+++ b/Source/PluginEditorObject.hpp
@@ -59,6 +59,8 @@ protected:
     
     void startEdition() noexcept;
     void stopEdition() noexcept;
+
+    Label* objectLabel;
     
     pd::Gui     gui;
     CamomileEditorMouseManager&   patch;
@@ -131,7 +133,7 @@ public:
 class GuiPanel : public PluginEditorObject
 {
 public:
-    GuiPanel(CamomileEditorMouseManager& p, pd::Gui& g);
+    GuiPanel(CamomileEditorMouseManager& p, pd::Gui& g); ///: PluginEditorObject(p, g) {}
     void paint(Graphics& g) final;
 };
 


### PR DESCRIPTION
In order to enable instant refreshing of dynamically changed labels / guis, I had to add a x_dirty flag in struct _iemgui (g_all_guis.h). This flag is set every time a gui is moved, size-changed, label-changed....
The PluginEditorObject.update() function checks this flag and, if necessary, calls repaint()

[LibPd-pure-data-src-changedFiles.zip](https://github.com/pierreguillot/Camomile/files/4643608/LibPd-pure-data-src-changedFiles.zip)
