### PR TITLE
lv2_file_generator: Only print error in error case

### DIFF
--- a/LV2/lv2_file_generator/main.c
+++ b/LV2/lv2_file_generator/main.c
@@ -83,7 +83,10 @@ int main(int argc, const char * argv[]) {
         {
             (*method)(argv[2]);
         }
-        printf("can't load methods lv2_generate_ttl\n");
+        else
+        {
+            printf("can't load method lv2_generate_ttl\n");
+        }
         if((error = dlerror()) != NULL)
         {
             printf("error: %s", error);


### PR DESCRIPTION
So far, the error message "can't load method lv2_generate_ttl" was
printed inconditionally, even the dlsym handle was valid (and the method
was called already).

Change this to only display the error, if the method was really not
found.

Also fix the typo "methods" -> "method" in the message.