### PR TITLE
makePresetsFile(): plugin parameters should be indexed by j, not i

### DIFF
--- a/LV2/juce_LV2_FileCreator.cpp
+++ b/LV2/juce_LV2_FileCreator.cpp
@@ -515,9 +515,9 @@ class JuceLV2FileCreator
                     preset += "    [\n";
                 }
                 
-                String const paramName = params[i]->getName(1000);
+                String const paramName = params[j]->getName(1000);
                 preset += "        lv2:symbol \"" + nameToSymbol(paramName, j) + "\" ;\n";
-                preset += "        pset:value " + String::formatted("%f", safeParamValue(params[i]->getValue())) + " ;\n";
+                preset += "        pset:value " + String::formatted("%f", safeParamValue(params[j]->getValue())) + " ;\n";
                 
                 if (j + 1 == params.size())
                 {


### PR DESCRIPTION
In the method `makePresetsFile()`, the variable `i` is used to loop over every preset which is being saved. Variable `j` is used in an inner loop to loop over plugin parameters. However, the array `params` was being accessed using `i` as an index, rather than `j`.

If you have, e.g. 4 presets for a plugin that accepts 2 parameters, the previous code tries to access `params[2]` and `params[3]`, which are out of bounds because there are only 2 parameters. This was leading to segfaults when I built the Bulgroz and Castafiore plugins.