### PR TITLE
#286 - fix hang when >1 Camomile LV2 plugin is loaded on Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,7 +130,11 @@ target_sources(CamomileFx PRIVATE ${CamomileSources} ${CamomilePdSources})
 
 add_library(Camomile_LV2 SHARED ${CamomileLV2Sources})
 target_link_libraries(Camomile_LV2 PRIVATE CamomileFx)
-set_target_properties(Camomile_LV2 PROPERTIES PREFIX "")
+set_target_properties(Camomile_LV2 PROPERTIES PREFIX "" CXX_STANDARD 20)
+
+if(${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU")
+    target_compile_options(Camomile_LV2 PRIVATE "-fno-gnu-unique")
+endif()
 
 set(CAMOMILE_COMPILE_DEFINITIONS
     JUCE_APP_CONFIG_HEADER="${SOURCES_DIRECTORY}/PluginConfig.h"

--- a/LV2/juce_LV2_FileCreator.cpp
+++ b/LV2/juce_LV2_FileCreator.cpp
@@ -515,9 +515,9 @@ class JuceLV2FileCreator
                     preset += "    [\n";
                 }
                 
-                String const paramName = params[i]->getName(1000);
+                String const paramName = params[j]->getName(1000);
                 preset += "        lv2:symbol \"" + nameToSymbol(paramName, j) + "\" ;\n";
-                preset += "        pset:value " + String::formatted("%f", safeParamValue(params[i]->getValue())) + " ;\n";
+                preset += "        pset:value " + String::formatted("%f", safeParamValue(params[j]->getValue())) + " ;\n";
                 
                 if (j + 1 == params.size())
                 {

--- a/Plugins/camomile
+++ b/Plugins/camomile
@@ -82,7 +82,7 @@ generate_plugin_lv2_mac() {
         mkdir "$plugin_output_dir/$plugin_name.lv2/Contents"
         mkdir "$plugin_output_dir/$plugin_name.lv2/Contents/Resources"
         cp -f "$ThisPath/$CamomileLV2.$AppleLV2Extension" "$plugin_output_dir/$plugin_name.lv2/$plugin_name.$AppleLV2Extension"
-        cp -rf "$plugin_input_dir"/* "$plugin_output_dir/$plugin_name.lv2/Contents/Resources"
+        cp -RfL "$plugin_input_dir"/* "$plugin_output_dir/$plugin_name.lv2/Contents/Resources"
         for subfile in $(find "$plugin_output_dir/$plugin_name.lv2")
         do
           xattr -d com.apple.quarantine "$subfile"
@@ -181,8 +181,8 @@ generate_plugin_au_mac() {
             rm -rf "$plugin_output_dir/$plugin_name.$AppleAuExtension"
         fi
 
-        cp -rf "$ThisPath/$camo_name.$AppleAuExtension" $plugin_output_dir/$plugin_name.$AppleAuExtension
-        cp -rf "$plugin_input_dir"/* "$plugin_output_dir/$plugin_name.$AppleAuExtension/Contents/Resources"
+        cp -Rf "$ThisPath/$camo_name.$AppleAuExtension" $plugin_output_dir/$plugin_name.$AppleAuExtension
+        cp -RfL "$plugin_input_dir"/* "$plugin_output_dir/$plugin_name.$AppleAuExtension/Contents/Resources"
         xattr -d com.apple.quarantine "$plugin_output_dir/$plugin_name.$AppleAuExtension"
         for subfile in $(find "$plugin_output_dir/$plugin_name.$AppleAuExtension/Contents")
         do
@@ -235,8 +235,8 @@ generate_plugin_vst3_mac() {
             rm -rf "$plugin_output_dir/$plugin_name.$AppleVst3Extension"
         fi
 
-        cp -rf "$ThisPath/$camo_name.$AppleVst3Extension" "$plugin_output_dir/$plugin_name.$AppleVst3Extension"
-        cp -rf "$plugin_input_dir"/* "$plugin_output_dir/$plugin_name.$AppleVst3Extension/Contents/Resources"
+        cp -Rf "$ThisPath/$camo_name.$AppleVst3Extension" "$plugin_output_dir/$plugin_name.$AppleVst3Extension"
+        cp -RfL "$plugin_input_dir"/* "$plugin_output_dir/$plugin_name.$AppleVst3Extension/Contents/Resources"
         xattr -d com.apple.quarantine "$plugin_output_dir/$plugin_name.$AppleVst3Extension"
         for subfile in $(find "$plugin_output_dir/$plugin_name.$AppleVst3Extension/Contents")
         do
@@ -274,7 +274,7 @@ generate_plugin_lv2_linux() {
 
         mkdir "$plugin_output_dir/$plugin_name.lv2"
         cp -f "$ThisPath/$CamomileLV2.$LinuxLV2Extension" "$plugin_output_dir/$plugin_name.lv2/$plugin_name.$LinuxLV2Extension"
-        cp -rf "$plugin_input_dir"/* "$plugin_output_dir/$plugin_name.lv2"
+        cp -RfL "$plugin_input_dir"/* "$plugin_output_dir/$plugin_name.lv2"
 
         LD_LIBRARY_PATH=$PWD "$ThisPath/lv2_file_generator" "$plugin_output_dir/$plugin_name.lv2/$plugin_name.$LinuxLV2Extension" $plugin_name
         mv -f "$PWD/manifest.ttl" "$plugin_output_dir/$plugin_name.lv2/manifest.ttl"
@@ -324,8 +324,8 @@ generate_plugin_vst3_linux() {
             rm -rf $plugin_bundle
         fi
 
-        cp -rf "$ThisPath/$camo_name.$LinuxVst3Extension" $plugin_bundle
-        cp -rf "$plugin_input_dir"/* "$plugin_bundle/Contents/x86_64-linux"
+        cp -Rf "$ThisPath/$camo_name.$LinuxVst3Extension" $plugin_bundle
+        cp -RfL "$plugin_input_dir"/* "$plugin_bundle/Contents/x86_64-linux"
         mv -f "$plugin_bundle/Contents/x86_64-linux/$camo_name.so" "$plugin_bundle/Contents/x86_64-linux/$plugin_name.so"
         post_log "$plugin_output_dir/$plugin_name.$LinuxVst3Extension"
     else


### PR DESCRIPTION
This issue was ultimately caused by an object buried in the JUCE code having an inappropriate scope - GCC made the object a "unique global symbol", which means there is only one instance across the current process. When multiple plugins were loaded, they all shared this instance, but did not share other relevant objects (from the JUCE code), causing havoc. See #286 for al the gory details.

The fix is to ban the compiler from marking symbols as "unique global".

Also set the C++ standard to be C++20 for the Camomile_LV2 meta-plugin, in line with the other meta-plugins.