### PR TITLE
openpanel/savepanel fixes

### DIFF
--- a/Source/PluginEditorInteraction.cpp
+++ b/Source/PluginEditorInteraction.cpp
@@ -259,7 +259,10 @@ bool CamomileEditorMessageManager::processMessages()
             m_file_chooser = std::make_unique<FileChooser>("Open...", File(message[1]), "", useNative);
             if(m_file_chooser != nullptr)
             {
-                auto constexpr folderChooserFlags = FileChooserFlags::openMode | FileChooserFlags::canSelectDirectories;
+                auto constexpr folderChooserFlags = \
+                    FileChooserFlags::openMode \
+                    | FileChooserFlags::canSelectFiles \
+                    | FileChooserFlags::canSelectDirectories;
                 auto const suspend = !message[2].empty();
                 WeakReference<CamomileEditorMessageManager> weakReference(this);
                 m_file_chooser->launchAsync(folderChooserFlags, [=, this](FileChooser const& fileChooser)
@@ -292,7 +295,11 @@ bool CamomileEditorMessageManager::processMessages()
             m_file_chooser = std::make_unique<FileChooser>("Save...", File(message[1]), "", useNative);
             if(m_file_chooser != nullptr)
             {
-                auto constexpr folderChooserFlags = FileChooserFlags::saveMode | FileChooserFlags::canSelectDirectories | FileChooserFlags::warnAboutOverwriting;
+                auto constexpr folderChooserFlags = \
+                    FileChooserFlags::saveMode \
+                    | FileChooserFlags::canSelectFiles \
+                    | FileChooserFlags::canSelectDirectories \
+                    | FileChooserFlags::warnAboutOverwriting;
                 auto const suspend = !message[2].empty();
                 WeakReference<CamomileEditorMessageManager> weakReference(this);
                 m_file_chooser->launchAsync(folderChooserFlags, [=, this](FileChooser const& fileChooser)

--- a/Source/PluginEditorInteraction.cpp
+++ b/Source/PluginEditorInteraction.cpp
@@ -308,15 +308,11 @@ bool CamomileEditorMessageManager::processMessages()
                     {
                         return;
                     }
-                    auto const file = fileChooser.getResult();
-                    if(!file.existsAsFile())
-                    {
-                        return;
-                    }
                     if(suspend)
                     {
                         m_processor.suspendProcessing(true);
                     }
+                    auto const file = fileChooser.getResult();
                     auto const path = file.getFullPathName().replaceCharacter('\\', '/').toStdString();
                     m_processor.enqueueMessages(string_savepanel, string_symbol, {path});
                     if(suspend)


### PR DESCRIPTION
* Fix #300 - the file picker opened by [openpanel] will now list files, not just directories
* [savepanel] - currently, the savepanel code checks if a file already exists at the file name chosen by the user. If no file exists there, the save is aborted. This makes it impossible to save under a new filename, which is undesirable. Therefore, this check is removed with this PR.